### PR TITLE
Note for nproc alternative on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ $ cd riscv-gnu-toolchain
 $ git submodule update --init --recursive --progress
 # ckb-vm doesn't provide floating point support
 $ ./configure --prefix=$RISCV --with-arch=rv64imac
+# On macOS use `make -j$(getconf _NPROCESSORS_ONLN)` instead as there's no nproc command
 $ make -j$(nproc)
 ```
 


### PR DESCRIPTION
Make `make jN` great again on macOS.