### PR TITLE
Fix load script argc

### DIFF
--- a/mruby-ckb/src/ckb.c
+++ b/mruby-ckb/src/ckb.c
@@ -443,7 +443,7 @@ mrb_mruby_ckb_gem_init(mrb_state* mrb)
   mrb_ckb = mrb_define_module(mrb, "CKB");
   mrb_define_module_function(mrb, mrb_ckb, "load_tx", ckb_mrb_load_tx, MRB_ARGS_NONE());
   mrb_define_module_function(mrb, mrb_ckb, "load_script_hash", ckb_mrb_load_script_hash, MRB_ARGS_REQ(3));
-  mrb_define_module_function(mrb, mrb_ckb, "load_script", ckb_mrb_load_script, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, mrb_ckb, "load_script", ckb_mrb_load_script, MRB_ARGS_REQ(3));
   mrb_define_module_function(mrb, mrb_ckb, "load_input_unlock_args", ckb_mrb_load_input_unlock_args, MRB_ARGS_REQ(1));
   mrb_define_module_function(mrb, mrb_ckb, "load_input_out_point", ckb_mrb_load_input_out_point, MRB_ARGS_REQ(2));
   mrb_define_module_function(mrb, mrb_ckb, "debug", ckb_mrb_debug, MRB_ARGS_REQ(1));

--- a/mruby-secp256k1/src/secp256k1.c
+++ b/mruby-secp256k1/src/secp256k1.c
@@ -85,7 +85,7 @@ secp256k1_mrb_sign(mrb_state *mrb, mrb_value obj)
   size_t len = 256;
   ret = secp256k1_ecdsa_signature_serialize_der(&context, buf, &len, &signature);
   if (ret == 0) {
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "secp256k1 signature serializing failure!");
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "secp256k1 signature_der serializing failure!");
   }
 
   return mrb_str_new(mrb, buf, len);
@@ -123,7 +123,7 @@ secp256k1_mrb_verify(mrb_state *mrb, mrb_value obj)
   ret = secp256k1_ecdsa_signature_parse_der(&context, &signature, signature_buf,
                                             signature_len);
   if (ret == 0) {
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "secp256k1 signature parsing failure!");
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "secp256k1 signature_der parsing failure!");
   }
 
   ret = secp256k1_ecdsa_verify(&context, &signature, message_buf, &pubkey);


### PR DESCRIPTION
* Fix argc of `load_script`
* Modify signature deserializing error log to contains signature encoding